### PR TITLE
PropTypes has been moved to a separate package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Image, ImageBackground, ActivityIndicator, View } from 'react-native';
 
 class ImageLoad extends React.Component {


### PR DESCRIPTION
React.PropTypes is no longer supported.